### PR TITLE
【Fiexd】rails gコマンドの際に無駄な helper や assets を生成させない

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -37,6 +37,8 @@ module FlowSample
       g.helper     false
     end
     
+    
+    
   end
   
   

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,6 +36,7 @@ module FlowSample
       g.assets     false
       g.helper     false
     end
+    
   end
   
   

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,12 @@ module FlowSample
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+    
+     config.generators do |g|
+      g.assets     false
+      g.helper     false
+    end
   end
+  
+  
 end


### PR DESCRIPTION
config/application.rb に対して下記のようなコードを追加した

config.generators do |g|
      g.assets     false
      g.helper     false
    end
